### PR TITLE
Fix variable

### DIFF
--- a/plugins/snapshots/erofs/erofs_linux.go
+++ b/plugins/snapshots/erofs/erofs_linux.go
@@ -399,7 +399,7 @@ func (s *snapshotter) runDmverity(ctx context.Context, id string) (string, error
 	devicePath := fmt.Sprintf("/dev/mapper/%s", dmName)
 	if _, err := os.Stat(devicePath); err == nil {
 		status, err := dmverity.Status(dmName)
-		log.L.Debugf("dmverity device status: ", status)
+		log.L.Debugf("dmverity device status: %v", status)
 		if err != nil {
 			return "", fmt.Errorf("failed to get dmverity device status: %w", err)
 		}


### PR DESCRIPTION
This PR fixes a logging issue in erofs_linux.go by updating the dmverity device status log statement to use a format string. This change ensures that the status value is properly formatted and displayed in the debug logs.

The `make test` in containerd was failing without this change